### PR TITLE
Update GitHub Actions workflows for CodeQL analysis and deployment

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: "CodeQL Analysis"
+name: "CodeQL Analysis (manual or PR to prod)"
 
 on:
   pull_request:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Run CodeQL and Deploy to GitHub Pages
+name: Deploy to GitHub Pages when pushed to prod
 
 on:
   push:
@@ -12,36 +12,6 @@ permissions:
   id-token: write
 
 jobs:
-
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'javascript-typescript' ]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:${{matrix.language}}"
 
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -69,6 +39,7 @@ jobs:
           VITE_SWIFT_SENSORS_API_KEY: ${{ secrets.VITE_SWIFT_SENSORS_API_KEY }}
           VITE_SWIFT_SENSORS_API_HOST: ${{ secrets.VITE_SWIFT_SENSORS_API_HOST }}
           VITE_SWIFT_SENSORS_PROD_APP_DOMAIN: ${{ secrets.VITE_SWIFT_SENSORS_PROD_APP_DOMAIN }}
+          VITE_SWIFT_SENSORS_PROD_PROXY_API_URL: ${{ secrets.VITE_SWIFT_SENSORS_PROD_PROXY_API_URL }}
         run: npm run build
 
       - name: Deploy


### PR DESCRIPTION
- Renamed the CodeQL analysis workflow to "CodeQL Analysis (manual or PR to prod)" for clarity on its usage.
- Updated the deployment workflow name to "Deploy to GitHub Pages when pushed to prod" to reflect its specific trigger.
- Removed the CodeQL analysis job from the deployment workflow to streamline the process and focus on deployment tasks.