### PR TITLE
Update Playwright configuration and GitHub Actions workflow

### DIFF
--- a/.github/workflows/test-gh-pages.yml
+++ b/.github/workflows/test-gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
           timeout=300
           interval=10
           elapsed=0
-          url="${{ vars.VITE_SWIFT_SENSORS_PROD_APP_URL }}"
+          url="https://${{ github.repository_owner }}.github.io/SwiftEventWeb"
           
           echo "Waiting for $url to be available..."
           
@@ -51,11 +51,11 @@ jobs:
 
       - name: Run Playwright tests
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ vars.VITE_SWIFT_SENSORS_PROD_APP_URL }}
+          PLAYWRIGHT_TEST_BASE_URL: https://${{ github.repository_owner }}.github.io/SwiftEventWeb
           VITE_SWIFT_SENSORS_USER: ${{ secrets.VITE_SWIFT_SENSORS_USER }}
           VITE_SWIFT_SENSORS_PASSWORD: ${{ secrets.VITE_SWIFT_SENSORS_PASSWORD }}
           VITE_SWIFT_SENSORS_API_KEY: ${{ secrets.VITE_SWIFT_SENSORS_API_KEY }}
-          VITE_SWIFT_SENSORS_PROD_APP_DOMAIN: ${{ vars.VITE_SWIFT_SENSORS_PROD_APP_DOMAIN }}
+          VITE_SWIFT_SENSORS_PROD_APP_DOMAIN: ${{ github.repository_owner }}.github.io
           VITE_SWIFT_SENSORS_PROD_PROXY_API_URL: ${{ vars.VITE_SWIFT_SENSORS_PROD_PROXY_API_URL }}
         run: npx playwright test
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "swifteventweb",
   "private": true,
-  "version": "1.3.18",
+  "version": "1.3.19",
   "type": "module",
   "base": "/SwiftEventWeb/",
-  "last-commit": "Sat Apr 19 16:16:37 CDT 2025",
+  "last-commit": "Sat Apr 19 16:29:40 CDT 2025",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     ['html'],
     ['list']
   ],
-  timeout: 120000,
+  timeout: 10000,
   use: {
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:5173',
     trace: 'on-first-retry',
@@ -18,7 +18,7 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   expect: {
-    timeout: 30000
+    timeout: 10000
   },
   projects: [
     {


### PR DESCRIPTION
- Reduced Playwright test timeout from 120 seconds to 10 seconds for faster feedback.
- Updated GitHub Actions workflow to use dynamic URLs based on the repository owner for deployment checks and environment variables.
- Ensured consistency in environment variable usage for Playwright tests.