### PR TITLE
Update Playwright configuration and Dashboard terminology

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "swifteventweb",
   "private": true,
-  "version": "1.3.19",
+  "version": "1.3.20",
   "type": "module",
   "base": "/SwiftEventWeb/",
-  "last-commit": "Sat Apr 19 16:29:40 CDT 2025",
+  "last-commit": "Sat Apr 19 16:39:15 CDT 2025",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     ['html'],
     ['list']
   ],
-  timeout: 10000,
+  timeout: 60000,
   use: {
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:5173',
     trace: 'on-first-retry',
@@ -18,7 +18,7 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   expect: {
-    timeout: 10000
+    timeout: 30000
   },
   projects: [
     {

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -41,7 +41,7 @@
 
     <div class="bg-white shadow rounded-lg p-6">
       <div class="flex justify-between items-center mb-4">
-        <h2 class="text-2xl font-bold text-gray-900">Measurements</h2>
+        <h2 class="text-2xl font-bold text-gray-900">Metrics</h2>
         <div class="flex items-center space-x-4">
           <span v-if="lastUpdateTime" class="text-sm text-gray-500 text-right min-w-[150px]">
             Last update: {{ elapsedTime }}

--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -47,7 +47,7 @@ test('login and verify dashboard', async ({ page }) => {
   // Verify section titles
   await expect(page.locator('h2').filter({ hasText: 'Account Information' })).toBeVisible();
   await expect(page.locator('h2').filter({ hasText: 'Devices' })).toBeVisible();
-  await expect(page.locator('h2').filter({ hasText: 'Measurements' })).toBeVisible();
+  await expect(page.locator('h2').filter({ hasText: 'Metrics' })).toBeVisible();
   await expect(page.locator('h2').filter({ hasText: 'Notification Settings' })).toBeVisible();
 
   // Wait for the update button to be visible
@@ -146,7 +146,7 @@ test('verify login with custom API key and logout', async ({ page }) => {
   // Verify section titles
   await expect(page.locator('h2').filter({ hasText: 'Account Information' })).toBeVisible();
   await expect(page.locator('h2').filter({ hasText: 'Devices' })).toBeVisible();
-  await expect(page.locator('h2').filter({ hasText: 'Measurements' })).toBeVisible();
+  await expect(page.locator('h2').filter({ hasText: 'Metrics' })).toBeVisible();
   await expect(page.locator('h2').filter({ hasText: 'Notification Settings' })).toBeVisible();
 
   // Click the logout button (assuming it's in the navigation)


### PR DESCRIPTION
- Increased Playwright test timeout from 10 seconds to 60 seconds for improved stability.
- Updated expected section title in the Dashboard from "Measurements" to "Metrics" for consistency.
- Adjusted test cases to reflect the updated section title in the login tests.