### PR TITLE
Update test-gh-pages.yml to change cron schedule for workflow

### DIFF
--- a/.github/workflows/test-gh-pages.yml
+++ b/.github/workflows/test-gh-pages.yml
@@ -2,7 +2,7 @@ name: Test GH Pages with Playwright
 
 on:
   schedule:
-    - cron: 0 6 * * *  # This cron expression runs the workflow every day at 6am UTC
+    - cron: 22 6 * * 6  # This cron expression runs the workflow every Saturday at 6am UTC 
   workflow_run:
     workflows: ["Deploy to GitHub Pages"]
     types:

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "swifteventweb",
   "private": true,
-  "version": "1.4.23",
+  "version": "1.4.24",
   "type": "module",
   "base": "/SwiftEventWeb/",
-  "last-commit": "Fri May  2 19:58:00 CDT 2025",
+  "last-commit": "Sun Jun 22 13:41:16 CDT 2025",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
- Modified the cron expression to run the workflow every Saturday at 6am UTC, enhancing the scheduling of tests for GitHub Pages.