### PR TITLE
Bump version to 1.4.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "swifteventweb",
   "private": true,
-  "version": "1.4.24",
+  "version": "1.4.25",
   "type": "module",
   "base": "/SwiftEventWeb/",
-  "last-commit": "Sun Jun 22 13:41:16 CDT 2025",
+  "last-commit": "Sun Apr 12 09:52:15 CDT 2026",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- Bump version to 1.4.25 to trigger a new release with correct source tarball (the v1.4.24 release had a stale source archive from 2025-06-22)
- Install pre-commit hook and update last-commit date

## Test plan
- [x] `npm run build` passes
- [x] All 6 Playwright E2E tests passed in prior commit
- [x] Only change is version/date in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)